### PR TITLE
bug: html rendering error

### DIFF
--- a/dashboard/badge.go
+++ b/dashboard/badge.go
@@ -12,7 +12,7 @@ type Badge struct {
 }
 
 func (badge Badge) Draw(canvas *svg.Canvas) {
-	canvas.Open()
+	canvas.Open(float64(badgeW), float64(badgeH))
 	origin := geo.Coordinate{X: 0, Y: 0}
 	badge.draw(canvas, origin)
 	canvas.Close()

--- a/dashboard/draw.go
+++ b/dashboard/draw.go
@@ -6,15 +6,12 @@ import (
 	geo "gobadge/svg/geometry"
 	"gobadge/svg/style"
 	"log"
-	"math"
 	"strings"
 )
 
-func (view *View) draw() {
+func (view *View) draw(count int, rows int, cols int) {
 
-	index, count := 0, len(view.Badges)
-	split := float64(count) / float64(view.Columns)
-	rows, cols := int(math.Ceil(split)), view.Columns
+	index := 0
 
 	for col := 0; col < cols; col++ {
 

--- a/dashboard/specs.go
+++ b/dashboard/specs.go
@@ -1,12 +1,12 @@
 package dashboard
 
 const (
-	badgeW    = 230
-	badgeH    = 20
-	headH     = 40
-	hpad      = 20
-	vpad      = 4
-	hoff      = 0
-	voff      = 57
+	badgeW    = 230 // badge width
+	badgeH    = 20  // badge height
+	headH     = 40  // header height
+	hpad      = 20  // horizontal badge padding
+	vpad      = 4   // vertical badge padding
+	hoff      = 0   // horizontal offset
+	voff      = 57  // vertical offset
 	blockfill = "#555555"
 )

--- a/dashboard/view.go
+++ b/dashboard/view.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"gobadge/svg"
+	"math"
 )
 
 type View struct {
@@ -17,8 +18,16 @@ type Header struct {
 }
 
 func (view *View) Draw() {
-	view.Canvas.Open()
+
+	count := len(view.Badges)
+	split := float64(count) / float64(view.Columns)
+	rows, cols := int(math.Ceil(split)), view.Columns
+
+	width := float64(((badgeW + 20) * (view.Columns - 1)) + badgeW)
+	height := float64(((badgeH + vpad) * rows) - vpad + voff)
+
+	view.Canvas.Open(width, height)
 	view.DrawHeader()
-	view.Draw()
+	view.draw(count, rows, cols)
 	view.Canvas.Close()
 }

--- a/examples/server.go
+++ b/examples/server.go
@@ -61,11 +61,18 @@ var dashboard = func(writer http.ResponseWriter, request *http.Request) {
 	view.Draw()
 }
 
+const (
+	port  = ":8080"
+	route = "/dashboard/example"
+)
+
 func main() {
 
 	// draw endpoint
-	http.HandleFunc("/dashboard/example", dashboard)
+	http.HandleFunc(route, dashboard)
+
+	log.Printf("listening on http://localhost%s%s", port, route)
 
 	// use goroutine to serve endpoint
-	http.ListenAndServe(":8080", nil)
+	http.ListenAndServe(port, nil)
 }

--- a/svg/canvas.go
+++ b/svg/canvas.go
@@ -3,6 +3,7 @@ package svg
 import (
 	"fmt"
 	"io"
+	"strings"
 )
 
 // Canvas is the SVG drawing canvas.
@@ -15,8 +16,20 @@ func New(writer io.Writer) *Canvas {
 	return &Canvas{writer}
 }
 
-func (canvas *Canvas) Open() error {
-	_, err := fmt.Fprint(canvas.Writer, `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">`)
+func (canvas *Canvas) Open(width float64, height float64) error {
+
+	open, close := `<svg `, `>`
+	_width := fmt.Sprintf(`width="%f"`, width)
+	_height := fmt.Sprintf(` height="%f"`, height)
+	version := `version="1.1"`
+	xmlns := `xmlns="http://www.w3.org/2000/svg"`
+	xlink := `xmlns:xlink="http://www.w3.org/1999/xlink"`
+
+	elements := []string{open, _width, _height, version, xmlns, xlink, close}
+	output := strings.Join(elements, " ")
+
+	_, err := fmt.Fprint(canvas.Writer, output)
+
 	return err
 }
 


### PR DESCRIPTION
SVG badges were inconsistently rendering, most commonly when being displayed in HTML. This bug is not visible in Postman, but _is_ visible in Mattermost, Confluence, and Bitbucket READMEs.
The fix was to dynamically the width and height of the SVG based on the badge count and column breakdown.
New output: `<svg width="{ width }" height="{ height }">`